### PR TITLE
Experimenting with data race detection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,5 +60,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@master
         with:
-          version: v1.37
+          version: v1.39
           skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,14 +9,11 @@ linters:
   disable:
     - cyclop
     - exhaustivestruct
-    - forbidigo
     - funlen
-    - gci
     - gofumpt
-    - ifshort
+    - interfacer
     - lll
-    - nlreturn
-    - paralleltest
+    - maligned
+    - scopelint
     - testpackage
-    - thelper
     - wrapcheck

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ The authenticated client created here will automatically regenerate the token if
 
 ### Rate Limiting
 
-Apple imposes a rate limit on all API clients. The returned `Response.Rate` value contains the rate limit information from the most recent API call. If the API produces a rate limit error, it will be identifiable as an `ErrorResponse` with an error code of `429`. 
+Apple imposes a rate limit on all API clients. The returned `Response.Rate` value contains the rate limit information from the most recent API call. If the API produces a rate limit error, it will be identifiable as an `ErrorResponse` with an error code of `429`.
 
 Learn more about rate limiting at <https://developer.apple.com/documentation/appstoreconnectapi/identifying_rate_limits>.
 
 ### Pagination
 
-All requests for resource collections (apps, builds, beta groups, etc.) support pagination. Responses for paginated resources will contain a `Links` property of type `PagedDocumentLinks`, with `Reference` URLs for first, next, and self. A `Reference` can have its cursor extracted with the `Cursor()` method, and that can be passed to a query param using its `Cursor` field. You can also find more information about the per-page limit and total count of resources in the response's `Meta` field of type `PagingInformation`.  
+All requests for resource collections (apps, builds, beta groups, etc.) support pagination. Responses for paginated resources will contain a `Links` property of type `PagedDocumentLinks`, with `Reference` URLs for first, next, and self. A `Reference` can have its cursor extracted with the `Cursor()` method, and that can be passed to a query param using its `Cursor` field. You can also find more information about the per-page limit and total count of resources in the response's `Meta` field of type `PagingInformation`.
 
 ```go
 auth, _ = asc.NewTokenConfig(keyID, issuerID, expiryDuration, privateKey)
@@ -90,7 +90,7 @@ for {
 	if err != nil {
 		return err
 	}
-	allApps = append(allApps, apps.Data...)    
+	allApps = append(allApps, apps.Data...)
     if apps.Links.Next == nil {
         break
     }

--- a/asc/apps_metadata_age_ratings_test.go
+++ b/asc/apps_metadata_age_ratings_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestUpdateAgeRatingDeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AgeRatingDeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateAgeRatingDeclaration(ctx, "10", &AgeRatingDeclarationUpdateRequestAttributes{})
 	})

--- a/asc/apps_metadata_categories_test.go
+++ b/asc/apps_metadata_categories_test.go
@@ -28,24 +28,32 @@ import (
 )
 
 func TestListAppCategories(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoriesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppCategories(ctx, &ListAppCategoriesQuery{})
 	})
 }
 
 func TestListSubcategoriesForAppCategory(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoriesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListSubcategoriesForAppCategory(ctx, "10", &ListSubcategoriesForAppCategoryQuery{})
 	})
 }
 
 func TestGetAppCategory(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppCategory(ctx, "10", &GetAppCategoryQuery{})
 	})
 }
 
 func TestGetAppCategoryIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"appCategories"},{"type":"appInfos"}]}`, func(ctx context.Context, client *Client) {
 		category, _, err := client.Apps.GetAppCategory(ctx, "10", &GetAppCategoryQuery{})
 		assert.NoError(t, err)
@@ -57,42 +65,56 @@ func TestGetAppCategoryIncludeds(t *testing.T) {
 }
 
 func TestGetParentCategoryForAppCategory(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetParentCategoryForAppCategory(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})
 }
 
 func TestGetPrimaryCategoryForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetPrimaryCategoryForAppInfo(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})
 }
 
 func TestGetSecondaryCategoryForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetSecondaryCategoryForAppInfo(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})
 }
 
 func TestGetPrimarySubcategoryOneForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetPrimarySubcategoryOneForAppInfo(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})
 }
 
 func TestGetPrimarySubcategoryTwoForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetPrimarySubcategoryTwoForAppInfo(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})
 }
 
 func TestGetSecondarySubcategoryOneForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetSecondarySubcategoryOneForAppInfo(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})
 }
 
 func TestGetSecondarySubcategoryTwoForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppCategoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetSecondarySubcategoryTwoForAppInfo(ctx, "10", &GetAppCategoryForAppInfoQuery{})
 	})

--- a/asc/apps_metadata_eula.go
+++ b/asc/apps_metadata_eula.go
@@ -178,6 +178,7 @@ func (s *AppsService) UpdateEULA(ctx context.Context, id string, agreementText *
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_end_user_license_agreement
 func (s *AppsService) DeleteEULA(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("endUserLicenseAgreements/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/apps_metadata_eula_test.go
+++ b/asc/apps_metadata_eula_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestCreateEULA(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &EndUserLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateEULA(ctx, "", "", []string{"10"})
 	})
 }
 
 func TestUpdateEULA(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &EndUserLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateEULA(ctx, "10", String(""), []string{"10"})
 	})
 }
 
 func TestDeleteEULA(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteEULA(ctx, "10")
 	})
 }
 
 func TestGetEULA(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &EndUserLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetEULA(ctx, "10", &GetEULAQuery{})
 	})
 }
 
 func TestGetEULAForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &EndUserLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetEULAForApp(ctx, "10", &GetEULAForAppQuery{})
 	})

--- a/asc/apps_metadata_game_center_test.go
+++ b/asc/apps_metadata_game_center_test.go
@@ -26,36 +26,48 @@ import (
 )
 
 func TestListGameCenterEnabledVersionsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &GameCenterEnabledVersionsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListGameCenterEnabledVersionsForApp(ctx, "10", &ListGameCenterEnabledVersionsForAppQuery{})
 	})
 }
 
 func TestListCompatibleVersionsForGameCenterEnabledVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &GameCenterEnabledVersionsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListCompatibleVersionsForGameCenterEnabledVersion(ctx, "10", &ListCompatibleVersionsForGameCenterEnabledVersionQuery{})
 	})
 }
 
 func TestListCompatibleVersionIDsForGameCenterEnabledVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &GameCenterEnabledVersionCompatibleVersionsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListCompatibleVersionIDsForGameCenterEnabledVersion(ctx, "10", &ListCompatibleVersionIDsForGameCenterEnabledVersionQuery{})
 	})
 }
 
 func TestCreateCompatibleVersionsForGameCenterEnabledVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.CreateCompatibleVersionsForGameCenterEnabledVersion(ctx, "10", []string{"10"})
 	})
 }
 
 func TestUpdateCompatibleVersionsForGameCenterEnabledVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.UpdateCompatibleVersionsForGameCenterEnabledVersion(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveCompatibleVersionsForGameCenterEnabledVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.RemoveCompatibleVersionsForGameCenterEnabledVersion(ctx, "10", []string{"10"})
 	})

--- a/asc/apps_metadata_info_localizations.go
+++ b/asc/apps_metadata_info_localizations.go
@@ -202,5 +202,6 @@ func (s *AppsService) UpdateAppInfoLocalization(ctx context.Context, id string, 
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_info_localization
 func (s *AppsService) DeleteAppInfoLocalization(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appInfoLocalizations/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/apps_metadata_info_localizations_test.go
+++ b/asc/apps_metadata_info_localizations_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestListAppInfoLocalizationsForAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfoLocalizationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppInfoLocalizationsForAppInfo(ctx, "10", &ListAppInfoLocalizationsForAppInfoQuery{})
 	})
 }
 
 func TestGetAppInfoLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfoLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppInfoLocalization(ctx, "10", &GetAppInfoLocalizationQuery{})
 	})
 }
 
 func TestCreateAppInfoLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfoLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppInfoLocalization(ctx, AppInfoLocalizationCreateRequestAttributes{}, "")
 	})
 }
 
 func TestUpdateAppInfoLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfoLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateAppInfoLocalization(ctx, "10", &AppInfoLocalizationUpdateRequestAttributes{})
 	})
 }
 
 func TestDeleteAppInfoLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppInfoLocalization(ctx, "10")
 	})

--- a/asc/apps_metadata_infos_test.go
+++ b/asc/apps_metadata_infos_test.go
@@ -28,12 +28,16 @@ import (
 )
 
 func TestGetAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfoResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppInfo(ctx, "10", &GetAppInfoQuery{})
 	})
 }
 
 func TestGetAppInfoIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"appInfoLocalizations"},{"type":"appCategories"}]}`, func(ctx context.Context, client *Client) {
 		infos, _, err := client.Apps.GetAppInfo(ctx, "10", &GetAppInfoQuery{})
 		assert.NoError(t, err)
@@ -48,12 +52,16 @@ func TestGetAppInfoIncludeds(t *testing.T) {
 }
 
 func TestListAppInfosForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfosResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppInfosForApp(ctx, "10", &ListAppInfosForAppQuery{})
 	})
 }
 
 func TestUpdateAppInfo(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppInfoResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateAppInfo(ctx, "10", &AppInfoUpdateRequestRelationships{})
 	})

--- a/asc/apps_metadata_preview_sets.go
+++ b/asc/apps_metadata_preview_sets.go
@@ -171,6 +171,7 @@ func (s *AppsService) CreateAppPreviewSet(ctx context.Context, previewType Previ
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_preview_set
 func (s *AppsService) DeleteAppPreviewSet(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appPreviewSets/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/apps_metadata_preview_sets_test.go
+++ b/asc/apps_metadata_preview_sets_test.go
@@ -26,36 +26,48 @@ import (
 )
 
 func TestGetAppPreviewSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewSetResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppPreviewSet(ctx, "10", &GetAppPreviewSetQuery{})
 	})
 }
 
 func TestCreateAppPreviewSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewSetResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppPreviewSet(ctx, PreviewTypeiPadPro129, "")
 	})
 }
 
 func TestDeleteAppPreviewSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppPreviewSet(ctx, "10")
 	})
 }
 
 func TestListAppPreviewsForSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppPreviewsForSet(ctx, "10", &ListAppPreviewsForSetQuery{})
 	})
 }
 
 func TestListAppPreviewIDsForSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewSetAppPreviewsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppPreviewIDsForSet(ctx, "10", &ListAppPreviewIDsForSetQuery{})
 	})
 }
 
 func TestReplaceAppPreviewsForSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.ReplaceAppPreviewsForSet(ctx, "10", []string{"10"})
 	})

--- a/asc/apps_metadata_previews.go
+++ b/asc/apps_metadata_previews.go
@@ -239,5 +239,6 @@ func (s *AppsService) CommitAppPreview(ctx context.Context, id string, uploaded 
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_preview
 func (s *AppsService) DeleteAppPreview(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appPreviews/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/apps_metadata_previews_test.go
+++ b/asc/apps_metadata_previews_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestGetAppPreview(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppPreview(ctx, "10", &GetAppPreviewQuery{})
 	})
 }
 
 func TestCreateAppPreview(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppPreview(ctx, "", 0, "")
 	})
 }
 
 func TestCommitAppPreview(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CommitAppPreview(ctx, "10", Bool(true), String("10"), nil)
 	})
 }
 
 func TestDeleteAppPreview(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppPreview(ctx, "10")
 	})

--- a/asc/apps_metadata_routing.go
+++ b/asc/apps_metadata_routing.go
@@ -210,5 +210,6 @@ func (s *AppsService) CommitRoutingAppCoverage(ctx context.Context, id string, u
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_routing_app_coverage
 func (s *AppsService) DeleteRoutingAppCoverage(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("routingAppCoverages/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/apps_metadata_routing_test.go
+++ b/asc/apps_metadata_routing_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestGetRoutingAppCoverageForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &RoutingAppCoverageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetRoutingAppCoverageForAppStoreVersion(ctx, "10", &GetRoutingAppCoverageForVersionQuery{})
 	})
 }
 
 func TestGetRoutingAppCoverage(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &RoutingAppCoverageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetRoutingAppCoverage(ctx, "10", &GetRoutingAppCoverageQuery{})
 	})
 }
 
 func TestCreateRoutingAppCoverage(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &RoutingAppCoverageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateRoutingAppCoverage(ctx, "", 0, "")
 	})
 }
 
 func TestCommitRoutingAppCoverage(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &RoutingAppCoverageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CommitRoutingAppCoverage(ctx, "10", Bool(true), String("10"))
 	})
 }
 
 func TestDeleteRoutingAppCoverage(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteRoutingAppCoverage(ctx, "10")
 	})

--- a/asc/apps_metadata_screenshot_sets.go
+++ b/asc/apps_metadata_screenshot_sets.go
@@ -228,6 +228,7 @@ func (s *AppsService) CreateAppScreenshotSet(ctx context.Context, screenshotDisp
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_screenshot_set
 func (s *AppsService) DeleteAppScreenshotSet(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appScreenshotSets/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/apps_metadata_screenshot_sets_test.go
+++ b/asc/apps_metadata_screenshot_sets_test.go
@@ -26,36 +26,48 @@ import (
 )
 
 func TestGetAppScreenshotSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotSetResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppScreenshotSet(ctx, "10", &GetAppScreenshotSetQuery{})
 	})
 }
 
 func TestCreateAppScreenshotSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotSetResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppScreenshotSet(ctx, ScreenshotDisplayTypeAppiPadPro129, "")
 	})
 }
 
 func TestDeleteAppScreenshotSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppScreenshotSet(ctx, "10")
 	})
 }
 
 func TestListAppScreenshotsForSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppScreenshotsForSet(ctx, "10", &ListAppScreenshotsForSetQuery{})
 	})
 }
 
 func TestListAppScreenshotIDsForSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotSetAppScreenshotsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppScreenshotIDsForSet(ctx, "10", &ListAppScreenshotIDsForSetQuery{})
 	})
 }
 
 func TestReplaceAppScreenshotsForSet(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.ReplaceAppScreenshotsForSet(ctx, "10", []string{"10"})
 	})

--- a/asc/apps_metadata_screenshots.go
+++ b/asc/apps_metadata_screenshots.go
@@ -187,5 +187,6 @@ func (s *AppsService) CommitAppScreenshot(ctx context.Context, id string, upload
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_screenshot
 func (s *AppsService) DeleteAppScreenshot(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appScreenshots/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/apps_metadata_screenshots_test.go
+++ b/asc/apps_metadata_screenshots_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestGetAppScreenshot(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppScreenshot(ctx, "10", &GetAppScreenshotQuery{})
 	})
 }
 
 func TestCreateAppScreenshot(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppScreenshot(ctx, "", 0, "")
 	})
 }
 
 func TestCommitAppScreenshot(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CommitAppScreenshot(ctx, "10", Bool(true), String("10"))
 	})
 }
 
 func TestDeleteAppScreenshot(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppScreenshot(ctx, "10")
 	})

--- a/asc/apps_metadata_version_localizations.go
+++ b/asc/apps_metadata_version_localizations.go
@@ -243,6 +243,7 @@ func (s *AppsService) UpdateAppStoreVersionLocalization(ctx context.Context, id 
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version_localization
 func (s *AppsService) DeleteAppStoreVersionLocalization(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appStoreVersionLocalizations/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/apps_metadata_version_localizations_test.go
+++ b/asc/apps_metadata_version_localizations_test.go
@@ -28,18 +28,24 @@ import (
 )
 
 func TestListLocalizationsForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionLocalizationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListLocalizationsForAppStoreVersion(ctx, "10", &ListLocalizationsForAppStoreVersionQuery{})
 	})
 }
 
 func TestGetAppStoreVersionLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppStoreVersionLocalization(ctx, "10", &GetAppStoreVersionLocalizationQuery{})
 	})
 }
 
 func TestGetAppStoreVersionLocalizationIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"appScreenshotSets"},{"type":"appPreviewSets"}]}`, func(ctx context.Context, client *Client) {
 		localization, _, err := client.Apps.GetAppStoreVersionLocalization(ctx, "10", &GetAppStoreVersionLocalizationQuery{})
 		assert.NoError(t, err)
@@ -54,30 +60,40 @@ func TestGetAppStoreVersionLocalizationIncludeds(t *testing.T) {
 }
 
 func TestCreateAppStoreVersionLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppStoreVersionLocalization(ctx, AppStoreVersionLocalizationCreateRequestAttributes{}, "")
 	})
 }
 
 func TestUpdateAppStoreVersionLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateAppStoreVersionLocalization(ctx, "10", &AppStoreVersionLocalizationUpdateRequestAttributes{})
 	})
 }
 
 func TestDeleteAppStoreVersionLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppStoreVersionLocalization(ctx, "10")
 	})
 }
 
 func TestListAppScreenshotSetsForAppStoreVersionLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppScreenshotSetsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppScreenshotSetsForAppStoreVersionLocalization(ctx, "10", &ListAppScreenshotSetsForAppStoreVersionLocalizationQuery{})
 	})
 }
 
 func TestListAppPreviewSetsForAppStoreVersionLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreviewSetsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppPreviewSetsForAppStoreVersionLocalization(ctx, "10", &ListAppPreviewSetsForAppStoreVersionLocalizationQuery{})
 	})

--- a/asc/apps_metadata_versions.go
+++ b/asc/apps_metadata_versions.go
@@ -345,6 +345,7 @@ func (s *AppsService) UpdateAppStoreVersion(ctx context.Context, id string, attr
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version
 func (s *AppsService) DeleteAppStoreVersion(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appStoreVersions/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/apps_metadata_versions_test.go
+++ b/asc/apps_metadata_versions_test.go
@@ -28,18 +28,24 @@ import (
 )
 
 func TestListAppStoreVersionsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListAppStoreVersionsForApp(ctx, "10", &ListAppStoreVersionsQuery{})
 	})
 }
 
 func TestGetAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAppStoreVersion(ctx, "10", &GetAppStoreVersionQuery{})
 	})
 }
 
 func TestGetAppStoreVersionIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[
 		{"type":"ageRatingDeclarations"},{"type":"appStoreVersionLocalizations"},
 		{"type":"builds"},{"type":"appStoreVersionPhasedReleases"},
@@ -71,36 +77,48 @@ func TestGetAppStoreVersionIncludeds(t *testing.T) {
 }
 
 func TestCreateAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.CreateAppStoreVersion(ctx, AppStoreVersionCreateRequestAttributes{}, "10", String("10"))
 	})
 }
 
 func TestUpdateAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateAppStoreVersion(ctx, "10", &AppStoreVersionUpdateRequestAttributes{}, String("10"))
 	})
 }
 
 func TestDeleteAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.DeleteAppStoreVersion(ctx, "10")
 	})
 }
 
 func TestGetBuildIDForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionBuildLinkageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetBuildIDForAppStoreVersion(ctx, "10")
 	})
 }
 
 func TestUpdateBuildForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionBuildLinkageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateBuildForAppStoreVersion(ctx, "10", String("10"))
 	})
 }
 
 func TestGetAgeRatingDeclarationForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AgeRatingDeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetAgeRatingDeclarationForAppStoreVersion(ctx, "10", &GetAgeRatingDeclarationForAppStoreVersionQuery{})
 	})

--- a/asc/apps_test.go
+++ b/asc/apps_test.go
@@ -28,18 +28,24 @@ import (
 )
 
 func TestListApps(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListApps(ctx, &ListAppsQuery{})
 	})
 }
 
 func TestGetApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetApp(ctx, "10", &GetAppQuery{})
 	})
 }
 
 func TestGetAppIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[
 		{"type":"betaGroups"},{"type":"appStoreVersions"},{"type":"preReleaseVersions"},
 		{"type":"betaAppLocalizations"},{"type":"builds"},{"type":"betaLicenseAgreements"},
@@ -85,24 +91,32 @@ func TestGetAppIncludeds(t *testing.T) {
 }
 
 func TestUpdateApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.UpdateApp(ctx, "10", &AppUpdateRequestAttributes{}, []string{"10"}, []NewAppPriceRelationship{{StartDate: nil}})
 	})
 }
 
 func TestRemoveBetaTestersFromApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Apps.RemoveBetaTestersFromApp(ctx, "10", []string{"10"})
 	})
 }
 
 func TestListInAppPurchasesForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &InAppPurchasesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.ListInAppPurchasesForApp(ctx, "10", &ListInAppPurchasesQuery{})
 	})
 }
 
 func TestGetInAppPurchase(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &InAppPurchaseResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Apps.GetInAppPurchase(ctx, "10", &GetInAppPurchaseQuery{})
 	})

--- a/asc/asc.go
+++ b/asc/asc.go
@@ -340,7 +340,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	op := func() error {
 		if c.httpDebug {
 			if dump, err := httputil.DumpRequest(req, true); err == nil {
-				fmt.Printf("DEBUG request uri=%s\n%s\n", req.URL, dump)
+				fmt.Printf("DEBUG request uri=%s\n%s\n", req.URL, dump) // nolint: forbidigo
 			}
 		}
 
@@ -356,7 +356,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) (*Res
 
 		if c.httpDebug {
 			if dump, err := httputil.DumpResponse(resp, true); err == nil {
-				fmt.Printf("DEBUG response uri=%s\n%s\n", req.URL, dump)
+				fmt.Printf("DEBUG response uri=%s\n%s\n", req.URL, dump) // nolint: forbidigo
 			}
 		}
 
@@ -367,7 +367,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, v interface{}) (*Res
 
 	notify := func(err error, delay time.Duration) {
 		if c.httpDebug {
-			fmt.Printf("DEBUG error %v, retry in %v\n", err, delay)
+			fmt.Printf("DEBUG error %v, retry in %v\n", err, delay) // nolint: forbidigo
 		}
 	}
 

--- a/asc/asc_test.go
+++ b/asc/asc_test.go
@@ -37,6 +37,8 @@ import (
 const marshaledMockPayload = `{"value":"TEST"}`
 
 func TestNewClient(t *testing.T) {
+	t.Parallel()
+
 	c := NewClient(nil)
 
 	assert.Equal(t, defaultBaseURL, c.baseURL.String())
@@ -47,6 +49,8 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestSetHTTPDebug(t *testing.T) {
+	t.Parallel()
+
 	client := NewClient(nil)
 	client.SetHTTPDebug(true)
 	assert.True(t, client.httpDebug)
@@ -68,6 +72,8 @@ type mockBody struct {
 }
 
 func TestNilContextReturnsError(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer("", http.StatusOK, false)
 
 	defer server.Close()
@@ -77,6 +83,8 @@ func TestNilContextReturnsError(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer(marshaledMockPayload, http.StatusOK, true)
 	client.SetHTTPDebug(true)
 
@@ -91,6 +99,8 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetWithQuery(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer(marshaledMockPayload, http.StatusOK, true)
 
 	defer server.Close()
@@ -110,6 +120,8 @@ func TestGetWithQuery(t *testing.T) {
 }
 
 func TestGetWithQuery_Error(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer("", http.StatusOK, true)
 	defer server.Close()
 
@@ -121,6 +133,8 @@ func TestGetWithQuery_Error(t *testing.T) {
 }
 
 func TestGetError(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer(marshaledMockPayload, http.StatusOK, true)
 	defer server.Close()
 
@@ -133,6 +147,8 @@ func TestGetError(t *testing.T) {
 }
 
 func TestPost(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer(marshaledMockPayload, http.StatusOK, true)
 	defer server.Close()
 
@@ -147,6 +163,8 @@ func TestPost(t *testing.T) {
 }
 
 func TestPatch(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer(marshaledMockPayload, http.StatusOK, true)
 	defer server.Close()
 
@@ -161,6 +179,8 @@ func TestPatch(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
+
 	client, server := newServer(marshaledMockPayload, http.StatusOK, true)
 	defer server.Close()
 
@@ -173,12 +193,16 @@ func TestDelete(t *testing.T) {
 }
 
 func TestCheckGoodResponse(t *testing.T) {
+	t.Parallel()
+
 	resp := &Response{&http.Response{StatusCode: 200}, Rate{}}
 	err := checkResponse(resp)
 	assert.NoError(t, err)
 }
 
 func TestCheckBadResponse(t *testing.T) {
+	t.Parallel()
+
 	resp := &Response{
 		Response: &http.Response{
 			StatusCode: 400,
@@ -223,6 +247,8 @@ func TestCheckBadResponse(t *testing.T) {
 }
 
 func TestAppendingQueryOptions(t *testing.T) {
+	t.Parallel()
+
 	got, err := appendingQueryOptions("dog", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "dog", got)
@@ -262,6 +288,8 @@ func newServer(raw string, status int, addRateLimit bool) (*Client, *httptest.Se
 }
 
 func testEndpointWithResponse(t *testing.T, marshalledGot string, want interface{}, endpoint func(ctx context.Context, client *Client) (interface{}, *Response, error)) {
+	t.Helper()
+
 	client, server := newServer(marshalledGot, http.StatusOK, true)
 	defer server.Close()
 
@@ -276,6 +304,8 @@ func testEndpointWithResponse(t *testing.T, marshalledGot string, want interface
 }
 
 func testEndpointWithNoContent(t *testing.T, endpoint func(ctx context.Context, client *Client) (*Response, error)) {
+	t.Helper()
+
 	client, server := newServer("", http.StatusOK, false)
 	defer server.Close()
 
@@ -286,6 +316,8 @@ func testEndpointWithNoContent(t *testing.T, endpoint func(ctx context.Context, 
 }
 
 func testEndpointExpectingError(t *testing.T, marshalledGot string, endpoint func(ctx context.Context, client *Client) (interface{}, *Response, error)) {
+	t.Helper()
+
 	client, server := newServer(marshalledGot, http.StatusOK, true)
 	defer server.Close()
 

--- a/asc/auth_test.go
+++ b/asc/auth_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestNewTokenConfig(t *testing.T) {
+	t.Parallel()
+
 	// This is a key that I generated solely for mocking purposes. This is not a
 	// real secret, so don't get any funny ideas. If you need to regenerate it,
 	// run this openssl command in a shell and copy the contents of key.pem to the string:
@@ -65,11 +67,15 @@ PURJWPQa24fI+wNPDi4OzjkB2g6fa5BHqam1gRlZHe8BU3+IjuC3AUFz
 }
 
 func TestNewTokenConfigBadPEM(t *testing.T) {
+	t.Parallel()
+
 	_, err := NewTokenConfig("TEST", "TEST", 20*time.Minute, []byte("TEST"))
 	assert.Error(t, err, "Expected error for invalid PEM, got nil")
 }
 
 func TestNewTokenConfigPrivateKeyNotPKCS8(t *testing.T) {
+	t.Parallel()
+
 	var badKey = []byte(`
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIIXpcxwADKgwJSwxz24ypAMDFUHPrirqhcx0vimrl9L2oAoGCCqGSM49
@@ -83,6 +89,8 @@ oH1YGuY57H3BQ3zLPVPsN+A8xnInGDa8yQ==
 }
 
 func TestAuthTransport(t *testing.T) {
+	t.Parallel()
+
 	token := "TEST.TEST.TEST"
 	transport := AuthTransport{
 		jwtGenerator: &mockJWTGenerator{token: token},
@@ -97,6 +105,8 @@ func TestAuthTransport(t *testing.T) {
 }
 
 func TestAuthTransportCustomTransport(t *testing.T) {
+	t.Parallel()
+
 	token := "TEST.TEST.TEST"
 	transport := AuthTransport{
 		jwtGenerator: &mockJWTGenerator{token: token},

--- a/asc/builds_app_encryption_declarations_test.go
+++ b/asc/builds_app_encryption_declarations_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestListAppEncryptionDeclarations(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppEncryptionDeclarationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.ListAppEncryptionDeclarations(ctx, &ListAppEncryptionDeclarationsQuery{})
 	})
 }
 
 func TestGetAppEncryptionDeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppEncryptionDeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetAppEncryptionDeclaration(ctx, "10", &GetAppEncryptionDeclarationQuery{})
 	})
 }
 
 func TestGetAppForAppEncryptionDeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetAppForAppEncryptionDeclaration(ctx, "10", &GetAppForEncryptionDeclarationQuery{})
 	})
 }
 
 func TestAssignBuildsToAppEncryptionDeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Builds.AssignBuildsToAppEncryptionDeclaration(ctx, "10", []string{"10"})
 	})

--- a/asc/builds_build_icons_test.go
+++ b/asc/builds_build_icons_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestListIconsForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildIconsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.ListIconsForBuild(ctx, "10", &ListIconsQuery{})
 	})

--- a/asc/builds_test.go
+++ b/asc/builds_test.go
@@ -28,24 +28,32 @@ import (
 )
 
 func TestListBuilds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.ListBuilds(ctx, &ListBuildsQuery{})
 	})
 }
 
 func TestListBuildsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.ListBuildsForApp(ctx, "10", &ListBuildsForAppQuery{})
 	})
 }
 
 func TestGetBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetBuild(ctx, "10", &GetBuildQuery{})
 	})
 }
 
 func TestGetBuildIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[
 		{"type":"preReleaseVersions"},{"type":"betaTesters"},{"type":"betaBuildLocalizations"},
 		{"type":"appEncryptionDeclarations"},{"type":"betaAppReviewSubmissions"},{"type":"apps"},
@@ -82,72 +90,96 @@ func TestGetBuildIncludeds(t *testing.T) {
 }
 
 func TestGetAppForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetAppForBuild(ctx, "10", &GetAppForBuildQuery{})
 	})
 }
 
 func TestGetAppStoreVersionForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetAppStoreVersionForBuild(ctx, "10", &GetAppStoreVersionForBuildQuery{})
 	})
 }
 
 func TestGetBuildForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetBuildForAppStoreVersion(ctx, "10", &GetBuildForAppStoreVersionQuery{})
 	})
 }
 
 func TestUpdateBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.UpdateBuild(ctx, "10", Bool(true), nil, String("10"))
 	})
 }
 
 func TestUpdateAppEncryptionDeclarationForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Builds.UpdateAppEncryptionDeclarationForBuild(ctx, "10", String("10"))
 	})
 }
 
 func TestCreateAccessForBetaGroupsToBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Builds.CreateAccessForBetaGroupsToBuild(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveAccessForBetaGroupsFromBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Builds.RemoveAccessForBetaGroupsFromBuild(ctx, "10", []string{"10"})
 	})
 }
 
 func TestCreateAccessForIndividualTestersToBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Builds.CreateAccessForIndividualTestersToBuild(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveAccessForIndividualTestersFromBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Builds.RemoveAccessForIndividualTestersFromBuild(ctx, "10", []string{"10"})
 	})
 }
 
 func TestListResourceIDsForIndividualTestersForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildIndividualTestersLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.ListResourceIDsForIndividualTestersForBuild(ctx, "10", &ListResourceIDsForIndividualTestersForBuildQuery{})
 	})
 }
 
 func TestGetAppEncryptionDeclarationForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppEncryptionDeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetAppEncryptionDeclarationForBuild(ctx, "10", &GetAppEncryptionDeclarationForBuildQuery{})
 	})
 }
 
 func TestGetAppEncryptionDeclarationIDForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildAppEncryptionDeclarationLinkageResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Builds.GetAppEncryptionDeclarationIDForBuild(ctx, "10")
 	})

--- a/asc/included.go
+++ b/asc/included.go
@@ -375,196 +375,235 @@ func supportedIncludeTypes() func(string, []byte) (string, interface{}, error) {
 		"ageRatingDeclarations": func(b []byte) (string, interface{}, error) {
 			var v AgeRatingDeclaration
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"apps": func(b []byte) (string, interface{}, error) {
 			var v App
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appCategories": func(b []byte) (string, interface{}, error) {
 			var v AppCategory
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appEncryptionDeclarations": func(b []byte) (string, interface{}, error) {
 			var v AppEncryptionDeclaration
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appInfos": func(b []byte) (string, interface{}, error) {
 			var v AppInfo
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appInfoLocalizations": func(b []byte) (string, interface{}, error) {
 			var v AppInfoLocalization
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appPreOrders": func(b []byte) (string, interface{}, error) {
 			var v AppPreOrder
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appPreviewSets": func(b []byte) (string, interface{}, error) {
 			var v AppPreviewSet
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appPrices": func(b []byte) (string, interface{}, error) {
 			var v AppPrice
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appScreenshotSets": func(b []byte) (string, interface{}, error) {
 			var v AppScreenshotSet
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appStoreReviewDetails": func(b []byte) (string, interface{}, error) {
 			var v AppStoreReviewDetail
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appStoreVersions": func(b []byte) (string, interface{}, error) {
 			var v AppStoreVersion
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appStoreVersionLocalizations": func(b []byte) (string, interface{}, error) {
 			var v AppStoreVersionLocalization
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appStoreVersionPhasedReleases": func(b []byte) (string, interface{}, error) {
 			var v AppStoreVersionPhasedRelease
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"appStoreVersionSubmissions": func(b []byte) (string, interface{}, error) {
 			var v AppStoreVersionSubmission
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaAppLocalizations": func(b []byte) (string, interface{}, error) {
 			var v BetaAppLocalization
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaAppReviewDetails": func(b []byte) (string, interface{}, error) {
 			var v BetaAppReviewDetail
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaAppReviewSubmissions": func(b []byte) (string, interface{}, error) {
 			var v BetaAppReviewSubmission
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaBuildLocalizations": func(b []byte) (string, interface{}, error) {
 			var v BetaBuildLocalization
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaGroups": func(b []byte) (string, interface{}, error) {
 			var v BetaGroup
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaLicenseAgreements": func(b []byte) (string, interface{}, error) {
 			var v BetaLicenseAgreement
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"betaTesters": func(b []byte) (string, interface{}, error) {
 			var v BetaTester
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"builds": func(b []byte) (string, interface{}, error) {
 			var v Build
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"buildBetaDetails": func(b []byte) (string, interface{}, error) {
 			var v BuildBetaDetail
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"buildIcons": func(b []byte) (string, interface{}, error) {
 			var v BuildIcon
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"bundleIds": func(b []byte) (string, interface{}, error) {
 			var v BundleID
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"bundleIdCapabilities": func(b []byte) (string, interface{}, error) {
 			var v BundleIDCapability
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"certificates": func(b []byte) (string, interface{}, error) {
 			var v Certificate
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"devices": func(b []byte) (string, interface{}, error) {
 			var v Device
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"diagnosticSignatures": func(b []byte) (string, interface{}, error) {
 			var v DiagnosticSignature
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"endUserLicenseAgreements": func(b []byte) (string, interface{}, error) {
 			var v EndUserLicenseAgreement
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"gameCenterEnabledVersions": func(b []byte) (string, interface{}, error) {
 			var v GameCenterEnabledVersion
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"idfaDeclarations": func(b []byte) (string, interface{}, error) {
 			var v IDFADeclaration
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"inAppPurchases": func(b []byte) (string, interface{}, error) {
 			var v InAppPurchase
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"perfPowerMetrics": func(b []byte) (string, interface{}, error) {
 			var v PerfPowerMetric
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"preReleaseVersions": func(b []byte) (string, interface{}, error) {
 			var v PrereleaseVersion
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"profiles": func(b []byte) (string, interface{}, error) {
 			var v Profile
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"routingAppCoverages": func(b []byte) (string, interface{}, error) {
 			var v RoutingAppCoverage
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 		"territories": func(b []byte) (string, interface{}, error) {
 			var v Territory
 			err := json.Unmarshal(b, &v)
+
 			return v.Type, v, err
 		},
 	}

--- a/asc/included_test.go
+++ b/asc/included_test.go
@@ -43,6 +43,8 @@ func (i *mockIncluded) UnmarshalJSON(b []byte) error {
 }
 
 func TestIncluded(t *testing.T) {
+	t.Parallel()
+
 	var payload *mockPayloadIncluded
 
 	payload = nil
@@ -69,6 +71,8 @@ func TestIncluded(t *testing.T) {
 }
 
 func TestKnownIncludeTypes(t *testing.T) {
+	t.Parallel()
+
 	knownTypes := []string{"ageRatingDeclarations", "apps", "appCategories", "appEncryptionDeclarations",
 		"appInfos", "appInfoLocalizations", "appPreOrders", "appPreviewSets", "appPrices", "appScreenshotSets",
 		"appStoreReviewDetails", "appStoreVersions", "appStoreVersionLocalizations", "appStoreVersionPhasedReleases",

--- a/asc/paging_test.go
+++ b/asc/paging_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestReference(t *testing.T) {
+	t.Parallel()
+
 	marshaled := `{"self":"https://api.appstoreconnect.apple.com/me?cursor=TEST"}`
 
 	var links DocumentLinks
@@ -41,6 +43,8 @@ func TestReference(t *testing.T) {
 }
 
 func TestReferenceNoCursor(t *testing.T) {
+	t.Parallel()
+
 	ref := new(Reference)
 	assert.Empty(t, ref.Cursor())
 	ref = &Reference{url.URL{}}
@@ -48,6 +52,8 @@ func TestReferenceNoCursor(t *testing.T) {
 }
 
 func TestReferenceBadUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	marshaledNoString := `{"self":0}`
 	marshaledNoURL := `{"self":":"}`
 
@@ -59,6 +65,8 @@ func TestReferenceBadUnmarshal(t *testing.T) {
 }
 
 func TestNewRelationships(t *testing.T) {
+	t.Parallel()
+
 	var rel *relationshipDeclaration
 	rel = newRelationshipDeclaration(nil, "dog")
 	assert.Nil(t, rel)

--- a/asc/pricing_territories_test.go
+++ b/asc/pricing_territories_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestListTerritories(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &TerritoriesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListTerritories(ctx, &ListTerritoriesQuery{})
 	})
 }
 
 func TestListTerritoriesForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &TerritoriesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListTerritoriesForApp(ctx, "10", &ListTerritoriesQuery{})
 	})
 }
 
 func TestListTerritoriesForEULA(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &TerritoriesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListTerritoriesForEULA(ctx, "10", &ListTerritoriesQuery{})
 	})
 }
 
 func TestGetTerritoryForAppPrice(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &TerritoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.GetTerritoryForAppPrice(ctx, "10", &ListTerritoriesQuery{})
 	})

--- a/asc/pricing_test.go
+++ b/asc/pricing_test.go
@@ -26,12 +26,16 @@ import (
 )
 
 func TestListPricesForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPricesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListPricesForApp(ctx, "10", &ListPricesQuery{})
 	})
 }
 
 func TestGetPrice(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPriceResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.GetPrice(ctx, "10", &GetPriceQuery{})
 	})

--- a/asc/pricing_tiers_test.go
+++ b/asc/pricing_tiers_test.go
@@ -26,36 +26,48 @@ import (
 )
 
 func TestListAppPriceTiers(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPriceTiersResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListAppPriceTiers(ctx, &ListAppPriceTiersQuery{})
 	})
 }
 
 func TestGetAppPriceTier(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPriceTierResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.GetAppPriceTier(ctx, "10", &GetAppPriceTierQuery{})
 	})
 }
 
 func TestListPricePointsForAppPriceTier(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPricePointsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListPricePointsForAppPriceTier(ctx, "10", &ListPricePointsForAppPriceTierQuery{})
 	})
 }
 
 func TestListAppPricePoints(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPricePointsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.ListAppPricePoints(ctx, &ListAppPricePointsQuery{})
 	})
 }
 
 func TestGetTerritoryForAppPricePoint(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &TerritoryResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.GetTerritoryForAppPricePoint(ctx, "10", &GetTerritoryForAppPricePointQuery{})
 	})
 }
 
 func TestGetAppPricePoint(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPricePointResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Pricing.GetAppPricePoint(ctx, "10", &GetAppPricePointQuery{})
 	})

--- a/asc/provisioning_bundle_ids.go
+++ b/asc/provisioning_bundle_ids.go
@@ -224,6 +224,7 @@ func (s *ProvisioningService) UpdateBundleID(ctx context.Context, id string, nam
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_bundle_id
 func (s *ProvisioningService) DeleteBundleID(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("bundleIds/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/provisioning_bundle_ids_test.go
+++ b/asc/provisioning_bundle_ids_test.go
@@ -28,36 +28,48 @@ import (
 )
 
 func TestCreateBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.CreateBundleID(ctx, BundleIDCreateRequestAttributes{})
 	})
 }
 
 func TestUpdateBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.UpdateBundleID(ctx, "10", String(""))
 	})
 }
 
 func TestDeleteBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Provisioning.DeleteBundleID(ctx, "10")
 	})
 }
 
 func TestListBundleIDs(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListBundleIDs(ctx, &ListBundleIDsQuery{})
 	})
 }
 
 func TestGetBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.GetBundleID(ctx, "10", &GetBundleIDQuery{})
 	})
 }
 
 func TestGetBundleIDIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"profiles"},{"type":"bundleIdCapabilities"},{"type":"apps"}]}`, func(ctx context.Context, client *Client) {
 		bundleID, _, err := client.Provisioning.GetBundleID(ctx, "10", &GetBundleIDQuery{})
 		assert.NoError(t, err)
@@ -74,18 +86,24 @@ func TestGetBundleIDIncludeds(t *testing.T) {
 }
 
 func TestGetAppForBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.GetAppForBundleID(ctx, "10", &GetAppForBundleIDQuery{})
 	})
 }
 
 func TestListProfilesForBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &ProfilesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListProfilesForBundleID(ctx, "10", &ListProfilesForBundleIDQuery{})
 	})
 }
 
 func TestListCapabilitiesForBundleID(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDCapabilitiesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListCapabilitiesForBundleID(ctx, "10", &ListCapabilitiesForBundleIDQuery{})
 	})

--- a/asc/provisioning_capabilities.go
+++ b/asc/provisioning_capabilities.go
@@ -221,6 +221,7 @@ func (s *ProvisioningService) EnableCapability(ctx context.Context, capabilityTy
 // https://developer.apple.com/documentation/appstoreconnectapi/disable_a_capability
 func (s *ProvisioningService) DisableCapability(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("bundleIdCapabilities/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/provisioning_capabilities_test.go
+++ b/asc/provisioning_capabilities_test.go
@@ -26,20 +26,27 @@ import (
 )
 
 func TestEnableCapability(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDCapabilityResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.EnableCapability(ctx, CapabilityTypeAccessWifiInformation, []CapabilitySetting{}, "")
 	})
 }
 
 func TestDisableCapability(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Provisioning.DisableCapability(ctx, "10")
 	})
 }
 
 func TestUpdateCapability(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDCapabilityResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		capability := CapabilityTypeAppGroups
+
 		return client.Provisioning.UpdateCapability(ctx, "10", &capability, []CapabilitySetting{})
 	})
 }

--- a/asc/provisioning_certificates.go
+++ b/asc/provisioning_certificates.go
@@ -187,5 +187,6 @@ func (s *ProvisioningService) GetCertificate(ctx context.Context, id string, par
 // https://developer.apple.com/documentation/appstoreconnectapi/revoke_a_certificate
 func (s *ProvisioningService) RevokeCertificate(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("certificates/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/provisioning_certificates_test.go
+++ b/asc/provisioning_certificates_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestCreateCertificate(t *testing.T) {
+	t.Parallel()
+
 	testEndpointExpectingError(t, "{}", func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.CreateCertificate(ctx, CertificateTypeDevelopment, nil)
 	})
@@ -36,18 +38,24 @@ func TestCreateCertificate(t *testing.T) {
 }
 
 func TestListCertificates(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &CertificatesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListCertificates(ctx, &ListCertificatesQuery{})
 	})
 }
 
 func TestGetCertificate(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &CertificateResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.GetCertificate(ctx, "10", &GetCertificateQuery{})
 	})
 }
 
 func TestRevokeCertificate(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Provisioning.RevokeCertificate(ctx, "10")
 	})

--- a/asc/provisioning_devices_test.go
+++ b/asc/provisioning_devices_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestCreateDevice(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DeviceResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.CreateDevice(ctx, "", "", BundleIDPlatformiOS)
 	})
 }
 
 func TestListDevices(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DevicesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListDevices(ctx, &ListDevicesQuery{})
 	})
 }
 
 func TestGetDevice(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DeviceResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.GetDevice(ctx, "10", &GetDeviceQuery{})
 	})
 }
 
 func TestUpdateDevice(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DeviceResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.UpdateDevice(ctx, "10", String(""), String(""))
 	})

--- a/asc/provisioning_profiles.go
+++ b/asc/provisioning_profiles.go
@@ -198,6 +198,7 @@ func (s *ProvisioningService) CreateProfile(ctx context.Context, name string, pr
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_profile
 func (s *ProvisioningService) DeleteProfile(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("profiles/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/provisioning_profiles_test.go
+++ b/asc/provisioning_profiles_test.go
@@ -28,30 +28,40 @@ import (
 )
 
 func TestCreateProfile(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &ProfileResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.CreateProfile(ctx, "", "", "", []string{"10"}, []string{"10"})
 	})
 }
 
 func TestDeleteProfile(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Provisioning.DeleteProfile(ctx, "10")
 	})
 }
 
 func TestListProfiles(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &ProfilesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListProfiles(ctx, &ListProfilesQuery{})
 	})
 }
 
 func TestGetProfile(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &ProfileResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.GetProfile(ctx, "10", &GetProfileQuery{})
 	})
 }
 
 func TestGetProfileIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"bundleIds"},{"type":"certificates"},{"type":"devices"}]}`, func(ctx context.Context, client *Client) {
 		profile, _, err := client.Provisioning.GetProfile(ctx, "10", &GetProfileQuery{})
 		assert.NoError(t, err)
@@ -68,18 +78,24 @@ func TestGetProfileIncludeds(t *testing.T) {
 }
 
 func TestGetBundleIDForProfile(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BundleIDResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.GetBundleIDForProfile(ctx, "10", &GetBundleIDForProfileQuery{})
 	})
 }
 
 func TestListCertificatesInProfile(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &CertificatesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListCertificatesInProfile(ctx, "10", &ListCertificatesForProfileQuery{})
 	})
 }
 
 func TestListDevicesInProfile(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DevicesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Provisioning.ListDevicesInProfile(ctx, "10", &ListDevicesInProfileQuery{})
 	})

--- a/asc/publishing_phased_release.go
+++ b/asc/publishing_phased_release.go
@@ -170,6 +170,7 @@ func (s *PublishingService) UpdatePhasedRelease(ctx context.Context, id string, 
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version_phased_release
 func (s *PublishingService) DeletePhasedRelease(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appStoreVersionPhasedReleases/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/publishing_phased_release_test.go
+++ b/asc/publishing_phased_release_test.go
@@ -26,26 +26,36 @@ import (
 )
 
 func TestCreatePhasedRelease(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionPhasedReleaseResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		state := PhasedReleaseStateActive
+
 		return client.Publishing.CreatePhasedRelease(ctx, &state, "")
 	})
 }
 
 func TestUpdatePhasedRelease(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionPhasedReleaseResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		state := PhasedReleaseStateActive
+
 		return client.Publishing.UpdatePhasedRelease(ctx, "10", &state)
 	})
 }
 
 func TestDeletePhasedRelease(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Publishing.DeletePhasedRelease(ctx, "10")
 	})
 }
 
 func TestGetAppStoreVersionPhasedReleaseForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionPhasedReleaseResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Publishing.GetAppStoreVersionPhasedReleaseForAppStoreVersion(ctx, "10", &GetAppStoreVersionPhasedReleaseForAppStoreVersionQuery{})
 	})

--- a/asc/publishing_preorder.go
+++ b/asc/publishing_preorder.go
@@ -188,5 +188,6 @@ func (s *PublishingService) UpdatePreOrder(ctx context.Context, id string, appRe
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_pre-order
 func (s *PublishingService) DeletePreOrder(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appPreOrders/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/publishing_preorder_test.go
+++ b/asc/publishing_preorder_test.go
@@ -27,30 +27,40 @@ import (
 )
 
 func TestGetPreOrder(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreOrderResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Publishing.GetPreOrder(ctx, "10", &GetPreOrderQuery{})
 	})
 }
 
 func TestGetPreOrderForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreOrderResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Publishing.GetPreOrderForApp(ctx, "10", &GetPreOrderForAppQuery{})
 	})
 }
 
 func TestCreatePreOrder(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreOrderResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Publishing.CreatePreOrder(ctx, &Date{time.Now()}, "")
 	})
 }
 
 func TestUpdatePreOrder(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppPreOrderResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Publishing.UpdatePreOrder(ctx, "10", &Date{time.Now()})
 	})
 }
 
 func TestDeletePreOrder(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Publishing.DeletePreOrder(ctx, "10")
 	})

--- a/asc/reporting_power_performance_metrics_test.go
+++ b/asc/reporting_power_performance_metrics_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestGetPerfPowerMetricsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &PerfPowerMetricsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Reporting.GetPerfPowerMetricsForApp(ctx, "10", &GetPerfPowerMetricsQuery{})
 	})
 }
 
 func TestGetPerfPowerMetricsForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &PerfPowerMetricsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Reporting.GetPerfPowerMetricsForBuild(ctx, "10", &GetPerfPowerMetricsQuery{})
 	})
 }
 
 func TestListDiagnosticSignaturesForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DiagnosticSignaturesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Reporting.ListDiagnosticSignaturesForBuild(ctx, "10", &ListDiagnosticsSignaturesQuery{})
 	})
 }
 
 func TestGetLogsForDiagnosticSignature(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &DiagnosticLogsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Reporting.GetLogsForDiagnosticSignature(ctx, "10", &GetLogsForDiagnosticSignatureQuery{})
 	})

--- a/asc/reporting_sales_finance_reports_test.go
+++ b/asc/reporting_sales_finance_reports_test.go
@@ -26,12 +26,16 @@ import (
 )
 
 func TestDownloadFinanceReports(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "ahhhhhhh", nil, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Reporting.DownloadFinanceReports(ctx, &DownloadFinanceReportsQuery{})
 	})
 }
 
 func TestDownloadSalesAndTrendsReports(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "ahhhhhhh", nil, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Reporting.DownloadSalesAndTrendsReports(ctx, &DownloadSalesAndTrendsReportsQuery{})
 	})

--- a/asc/schema_test.go
+++ b/asc/schema_test.go
@@ -46,6 +46,8 @@ func dateContainerJSON(date string) string {
 }
 
 func TestDateMarshal(t *testing.T) {
+	t.Parallel()
+
 	want := dateContainerJSON("2020-04-01")
 	b := newDateContainer(2020, 4, 1)
 	got, err := json.Marshal(b)
@@ -54,6 +56,8 @@ func TestDateMarshal(t *testing.T) {
 }
 
 func TestDateUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	want := time.Date(2020, 4, 1, 0, 0, 0, 0, time.UTC)
 	jsonStr := dateContainerJSON("2020-04-01")
 
@@ -64,6 +68,8 @@ func TestDateUnmarshal(t *testing.T) {
 }
 
 func TestDateUnmarshalWrongType(t *testing.T) {
+	t.Parallel()
+
 	jsonStr := `{"date":-1}`
 
 	var b dateContainer
@@ -72,6 +78,8 @@ func TestDateUnmarshalWrongType(t *testing.T) {
 }
 
 func TestDateUnmarshalInvalidDate(t *testing.T) {
+	t.Parallel()
+
 	jsonStr := dateContainerJSON("TEST")
 
 	var b dateContainer
@@ -96,6 +104,8 @@ func dateTimeContainerJSON(dateTime string) string {
 }
 
 func TestDateTimeMarshal(t *testing.T) {
+	t.Parallel()
+
 	want := dateTimeContainerJSON("2020-04-01T05:16:48.915+0000")
 	b := newDateTimeContainer(2020, 4, 1, 5, 16, 48, 915000000)
 	got, err := json.Marshal(b)
@@ -104,9 +114,10 @@ func TestDateTimeMarshal(t *testing.T) {
 }
 
 func TestDateTimeUnmarshal(t *testing.T) {
-	time.Local = time.UTC
-	want := time.Date(2020, 4, 1, 5, 16, 48, 915000000, time.Local)
-	jsonStr := dateTimeContainerJSON("2020-04-01T05:16:48.915+0000")
+	t.Parallel()
+
+	want := time.Date(2020, 4, 1, 5, 16, 48, 915000000, time.UTC)
+	jsonStr := dateTimeContainerJSON("2020-04-01T05:16:48.915Z")
 
 	var b dateTimeContainer
 	err := json.Unmarshal([]byte(jsonStr), &b)
@@ -115,6 +126,8 @@ func TestDateTimeUnmarshal(t *testing.T) {
 }
 
 func TestDateTimeUnmarshalWrongType(t *testing.T) {
+	t.Parallel()
+
 	jsonStr := `{"time":-1}`
 
 	var b dateTimeContainer
@@ -123,6 +136,8 @@ func TestDateTimeUnmarshalWrongType(t *testing.T) {
 }
 
 func TestDateTimeUnmarshalInvalidDate(t *testing.T) {
+	t.Parallel()
+
 	jsonStr := dateTimeContainerJSON("TEST")
 
 	var b dateTimeContainer
@@ -145,6 +160,8 @@ func emailContainerJSON(email string) string {
 }
 
 func TestEmailMarshal(t *testing.T) {
+	t.Parallel()
+
 	email := "my@email.com"
 	want := emailContainerJSON(email)
 	b := newEmailContainer(email)
@@ -154,12 +171,16 @@ func TestEmailMarshal(t *testing.T) {
 }
 
 func TestEmailMarshalInvalidEmail(t *testing.T) {
+	t.Parallel()
+
 	b := newEmailContainer("TEST")
 	_, err := json.Marshal(b)
 	assert.Error(t, err)
 }
 
 func TestEmailUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	want := "my@email.com"
 	jsonStr := emailContainerJSON(want)
 
@@ -170,6 +191,8 @@ func TestEmailUnmarshal(t *testing.T) {
 }
 
 func TestEmailUnmarshalWrongType(t *testing.T) {
+	t.Parallel()
+
 	jsonStr := `{"email":-1}`
 
 	var b emailContainer
@@ -178,6 +201,8 @@ func TestEmailUnmarshalWrongType(t *testing.T) {
 }
 
 func TestEmailUnmarshalInvalidEmail(t *testing.T) {
+	t.Parallel()
+
 	jsonStr := emailContainerJSON("TEST")
 
 	var b emailContainer
@@ -186,24 +211,32 @@ func TestEmailUnmarshalInvalidEmail(t *testing.T) {
 }
 
 func TestBool(t *testing.T) {
+	t.Parallel()
+
 	got := true
 	want := Bool(got)
 	assert.Equal(t, want, &got, "Bool returned same *bool, but they should differ")
 }
 
 func TestInt(t *testing.T) {
+	t.Parallel()
+
 	got := 100
 	want := Int(got)
 	assert.Equal(t, want, &got, "Int returned same *int, but they should differ")
 }
 
 func TestFloat(t *testing.T) {
+	t.Parallel()
+
 	got := 100.5
 	want := Float(got)
 	assert.Equal(t, want, &got, "Float returned same *float64, but they should differ")
 }
 
 func TestString(t *testing.T) {
+	t.Parallel()
+
 	got := "App Store Connect"
 	want := String(got)
 	assert.Equal(t, want, &got, "String returned same *string, but they should differ")

--- a/asc/submission_app_store_version_submissions.go
+++ b/asc/submission_app_store_version_submissions.go
@@ -100,6 +100,7 @@ func (s *SubmissionService) CreateSubmission(ctx context.Context, appStoreVersio
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_version_submission
 func (s *SubmissionService) DeleteSubmission(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appStoreVersionSubmissions/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/submission_app_store_version_submissions_test.go
+++ b/asc/submission_app_store_version_submissions_test.go
@@ -26,18 +26,24 @@ import (
 )
 
 func TestCreateSubmission(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionSubmissionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.CreateSubmission(ctx, "")
 	})
 }
 
 func TestDeleteSubmission(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Submission.DeleteSubmission(ctx, "10")
 	})
 }
 
 func TestGetAppStoreVersionSubmissionForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreVersionSubmissionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.GetAppStoreVersionSubmissionForAppStoreVersion(ctx, "10", &GetAppStoreVersionSubmissionForAppStoreVersionQuery{})
 	})

--- a/asc/submission_idfa_declarations.go
+++ b/asc/submission_idfa_declarations.go
@@ -156,6 +156,7 @@ func (s *SubmissionService) UpdateIDFADeclaration(ctx context.Context, id string
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_idfa_declaration
 func (s *SubmissionService) DeleteIDFADeclaration(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("idfaDeclarations/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/submission_idfa_declarations_test.go
+++ b/asc/submission_idfa_declarations_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestCreateIDFADeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &IDFADeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.CreateIDFADeclaration(ctx, IDFADeclarationCreateRequestAttributes{}, "")
 	})
 }
 
 func TestUpdateIDFADeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &IDFADeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.UpdateIDFADeclaration(ctx, "10", &IDFADeclarationUpdateRequestAttributes{})
 	})
 }
 
 func TestDeleteIDFADeclaration(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Submission.DeleteIDFADeclaration(ctx, "10")
 	})
 }
 
 func TestGetIDFADeclarationForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &IDFADeclarationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.GetIDFADeclarationForAppStoreVersion(ctx, "10", &GetIDFADeclarationForAppStoreVersionQuery{})
 	})

--- a/asc/submission_review_attachments.go
+++ b/asc/submission_review_attachments.go
@@ -206,5 +206,6 @@ func (s *SubmissionService) CommitAttachment(ctx context.Context, id string, upl
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_an_app_store_review_attachment
 func (s *SubmissionService) DeleteAttachment(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("appStoreReviewAttachments/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/submission_review_attachments_test.go
+++ b/asc/submission_review_attachments_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestGetAttachment(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewAttachmentResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.GetAttachment(ctx, "10", &GetAttachmentQuery{})
 	})
 }
 
 func TestListAttachmentsForReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewAttachmentsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.ListAttachmentsForReviewDetail(ctx, "10", &ListAttachmentQuery{})
 	})
 }
 
 func TestCreateAttachment(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewAttachmentResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.CreateAttachment(ctx, "", 0, "")
 	})
 }
 
 func TestCommitAttachment(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewAttachmentResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.CommitAttachment(ctx, "10", Bool(true), String("10"))
 	})
 }
 
 func TestDeleteAttachment(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Submission.DeleteAttachment(ctx, "10")
 	})

--- a/asc/submission_review_details_test.go
+++ b/asc/submission_review_details_test.go
@@ -26,24 +26,32 @@ import (
 )
 
 func TestCreateReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.CreateReviewDetail(ctx, &AppStoreReviewDetailCreateRequestAttributes{}, "")
 	})
 }
 
 func TestGetReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.GetReviewDetail(ctx, "10", &GetReviewDetailQuery{})
 	})
 }
 
 func TestGetReviewDetailsForAppStoreVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.GetReviewDetailsForAppStoreVersion(ctx, "10", &GetAppStoreReviewDetailsForAppStoreVersionQuery{})
 	})
 }
 
 func TestUpdateReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppStoreReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Submission.UpdateReviewDetail(ctx, "10", &AppStoreReviewDetailUpdateRequestAttributes{})
 	})

--- a/asc/testflight_beta_app_localizations.go
+++ b/asc/testflight_beta_app_localizations.go
@@ -246,5 +246,6 @@ func (s *TestflightService) UpdateBetaAppLocalization(ctx context.Context, id st
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_beta_app_localization
 func (s *TestflightService) DeleteBetaAppLocalization(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("betaAppLocalizations/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/testflight_beta_app_localizations_test.go
+++ b/asc/testflight_beta_app_localizations_test.go
@@ -26,42 +26,56 @@ import (
 )
 
 func TestListBetaAppLocalizations(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppLocalizationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaAppLocalizations(ctx, &ListBetaAppLocalizationsQuery{})
 	})
 }
 
 func TestGetBetaAppLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaAppLocalization(ctx, "10", &GetBetaAppLocalizationQuery{})
 	})
 }
 
 func TestGetAppForBetaAppLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetAppForBetaAppLocalization(ctx, "10", &GetAppForBetaAppLocalizationQuery{})
 	})
 }
 
 func TestListBetaAppLocalizationsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppLocalizationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaAppLocalizationsForApp(ctx, "10", &ListBetaAppLocalizationsForAppQuery{})
 	})
 }
 
 func TestCreateBetaAppLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.CreateBetaAppLocalization(ctx, BetaAppLocalizationCreateRequestAttributes{}, "")
 	})
 }
 
 func TestUpdateBetaAppLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.UpdateBetaAppLocalization(ctx, "10", &BetaAppLocalizationUpdateRequestAttributes{})
 	})
 }
 
 func TestDeleteBetaAppLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.DeleteBetaAppLocalization(ctx, "10")
 	})

--- a/asc/testflight_beta_app_review_detail_test.go
+++ b/asc/testflight_beta_app_review_detail_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestListBetaAppReviewDetails(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewDetailsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaAppReviewDetails(ctx, &ListBetaAppReviewDetailsQuery{})
 	})
 }
 
 func TestGetBetaAppReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaAppReviewDetail(ctx, "10", &GetBetaAppReviewDetailQuery{})
 	})
 }
 
 func TestGetAppForBetaAppReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetAppForBetaAppReviewDetail(ctx, "10", &GetAppForBetaAppReviewDetailQuery{})
 	})
 }
 
 func TestGetBetaAppReviewDetailsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaAppReviewDetailsForApp(ctx, "10", &GetBetaAppReviewDetailsForAppQuery{})
 	})
 }
 
 func TestUpdateBetaAppReviewDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.UpdateBetaAppReviewDetail(ctx, "10", &BetaAppReviewDetailUpdateRequestAttributes{})
 	})

--- a/asc/testflight_beta_app_review_submissions_test.go
+++ b/asc/testflight_beta_app_review_submissions_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestCreateBetaAppReviewSubmission(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewSubmissionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.CreateBetaAppReviewSubmission(ctx, "")
 	})
 }
 
 func TestListBetaAppReviewSubmissions(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewSubmissionsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaAppReviewSubmissions(ctx, &ListBetaAppReviewSubmissionsQuery{})
 	})
 }
 
 func TestGetBetaAppReviewSubmission(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewSubmissionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaAppReviewSubmission(ctx, "10", &GetBetaAppReviewSubmissionQuery{})
 	})
 }
 
 func TestGetBuildForBetaAppReviewSubmission(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBuildForBetaAppReviewSubmission(ctx, "10", &GetBuildForBetaAppReviewSubmissionQuery{})
 	})
 }
 
 func TestGetBetaAppReviewSubmissionForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaAppReviewSubmissionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaAppReviewSubmissionForBuild(ctx, "10", &GetBetaAppReviewSubmissionForBuildQuery{})
 	})

--- a/asc/testflight_beta_build_localizations.go
+++ b/asc/testflight_beta_build_localizations.go
@@ -241,5 +241,6 @@ func (s *TestflightService) UpdateBetaBuildLocalization(ctx context.Context, id 
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_beta_build_localization
 func (s *TestflightService) DeleteBetaBuildLocalization(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("betaBuildLocalizations/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }

--- a/asc/testflight_beta_build_localizations_test.go
+++ b/asc/testflight_beta_build_localizations_test.go
@@ -26,42 +26,56 @@ import (
 )
 
 func TestListBetaBuildLocalizations(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaBuildLocalizationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaBuildLocalizations(ctx, &ListBetaBuildLocalizationsQuery{})
 	})
 }
 
 func TestGetBetaBuildLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaBuildLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaBuildLocalization(ctx, "10", &GetBetaBuildLocalizationQuery{})
 	})
 }
 
 func TestGetBuildForBetaBuildLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBuildForBetaBuildLocalization(ctx, "10", &GetBuildForBetaBuildLocalizationQuery{})
 	})
 }
 
 func TestListBetaBuildLocalizationsForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaBuildLocalizationsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaBuildLocalizationsForBuild(ctx, "10", &ListBetaBuildLocalizationsForBuildQuery{})
 	})
 }
 
 func TestCreateBetaBuildLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaBuildLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.CreateBetaBuildLocalization(ctx, "", nil, "")
 	})
 }
 
 func TestUpdateBetaBuildLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaBuildLocalizationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.UpdateBetaBuildLocalization(ctx, "10", String(""))
 	})
 }
 
 func TestDeleteBetaBuildLocalization(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.DeleteBetaBuildLocalization(ctx, "10")
 	})

--- a/asc/testflight_beta_groups.go
+++ b/asc/testflight_beta_groups.go
@@ -286,6 +286,7 @@ func (s *TestflightService) UpdateBetaGroup(ctx context.Context, id string, attr
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_beta_group
 func (s *TestflightService) DeleteBetaGroup(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("betaGroups/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/testflight_beta_groups_test.go
+++ b/asc/testflight_beta_groups_test.go
@@ -28,36 +28,48 @@ import (
 )
 
 func TestCreateBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.CreateBetaGroup(ctx, BetaGroupCreateRequestAttributes{}, "", []string{"10"}, []string{"10"})
 	})
 }
 
 func TestUpdateBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.UpdateBetaGroup(ctx, "10", &BetaGroupUpdateRequestAttributes{})
 	})
 }
 
 func TestDeleteBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.DeleteBetaGroup(ctx, "10")
 	})
 }
 
 func TestListBetaGroups(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaGroups(ctx, &ListBetaGroupsQuery{})
 	})
 }
 
 func TestGetBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaGroup(ctx, "10", &GetBetaGroupQuery{})
 	})
 }
 
 func TestGetBetaGroupIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"apps"},{"type":"builds"},{"type":"betaTesters"}]}`, func(ctx context.Context, client *Client) {
 		group, _, err := client.TestFlight.GetBetaGroup(ctx, "10", &GetBetaGroupQuery{})
 		assert.NoError(t, err)
@@ -73,60 +85,80 @@ func TestGetBetaGroupIncludeds(t *testing.T) {
 }
 
 func TestGetAppForBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetAppForBetaGroup(ctx, "10", &GetAppForBetaGroupQuery{})
 	})
 }
 
 func TestListBetaGroupsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaGroupsForApp(ctx, "10", &ListBetaGroupsForAppQuery{})
 	})
 }
 
 func TestAddBetaTestersToBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.AddBetaTestersToBetaGroup(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveBetaTestersFromBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.RemoveBetaTestersFromBetaGroup(ctx, "10", []string{"10"})
 	})
 }
 
 func TestAddBuildsToBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.AddBuildsToBetaGroup(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveBuildsFromBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.RemoveBuildsFromBetaGroup(ctx, "10", []string{"10"})
 	})
 }
 
 func TestListBuildsForBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBuildsForBetaGroup(ctx, "10", &ListBuildsForBetaGroupQuery{})
 	})
 }
 
 func TestListBuildIDsForBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupBuildsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBuildIDsForBetaGroup(ctx, "10", &ListBuildIDsForBetaGroupQuery{})
 	})
 }
 
 func TestListBetaTestersForBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTestersResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaTestersForBetaGroup(ctx, "10", &ListBetaTestersForBetaGroupQuery{})
 	})
 }
 
 func TestListBetaTesterIDsForBetaGroup(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupBetaTestersLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaTesterIDsForBetaGroup(ctx, "10", &ListBetaTesterIDsForBetaGroupQuery{})
 	})

--- a/asc/testflight_beta_license_agreements_test.go
+++ b/asc/testflight_beta_license_agreements_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestListBetaLicenseAgreements(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaLicenseAgreementsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaLicenseAgreements(ctx, &ListBetaLicenseAgreementsQuery{})
 	})
 }
 
 func TestGetBetaLicenseAgreement(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaLicenseAgreement(ctx, "10", &GetBetaLicenseAgreementQuery{})
 	})
 }
 
 func TestGetAppForBetaLicenseAgreement(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetAppForBetaLicenseAgreement(ctx, "10", &GetAppForBetaLicenseAgreementQuery{})
 	})
 }
 
 func TestGetBetaLicenseAgreementForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaLicenseAgreementForApp(ctx, "10", &GetBetaLicenseAgreementForAppQuery{})
 	})
 }
 
 func TestUpdateBetaLicenseAgreement(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaLicenseAgreementResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.UpdateBetaLicenseAgreement(ctx, "10", String(""))
 	})

--- a/asc/testflight_beta_tester_invitations_test.go
+++ b/asc/testflight_beta_tester_invitations_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestCreateBetaTesterInvitation(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTesterInvitationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.CreateBetaTesterInvitation(ctx, "", "")
 	})

--- a/asc/testflight_beta_testers.go
+++ b/asc/testflight_beta_testers.go
@@ -249,8 +249,9 @@ func (s *TestflightService) CreateBetaTester(ctx context.Context, attributes Bet
 		Attributes: attributes,
 		Type:       "betaTesters",
 	}
+
 	anyBetaGroups := len(betaGroupIDs) > 0
-	anyBuilds := len(buildIDs) > 0
+	anyBuilds := len(buildIDs) > 0 // nolint: ifshort
 
 	if anyBetaGroups || anyBuilds {
 		req.Relationships = &betaTesterCreateRequestRelationships{}
@@ -277,6 +278,7 @@ func (s *TestflightService) CreateBetaTester(ctx context.Context, attributes Bet
 // https://developer.apple.com/documentation/appstoreconnectapi/delete_a_beta_tester
 func (s *TestflightService) DeleteBetaTester(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("betaTesters/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/testflight_beta_testers_test.go
+++ b/asc/testflight_beta_testers_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestCreateBetaTester(t *testing.T) {
+	t.Parallel()
+
 	email := Email("me@email.com")
 	want := &BetaTesterResponse{
 		Data: BetaTester{
@@ -42,24 +44,32 @@ func TestCreateBetaTester(t *testing.T) {
 }
 
 func TestDeleteBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.DeleteBetaTester(ctx, "10")
 	})
 }
 
 func TestListBetaTesters(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTestersResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaTesters(ctx, &ListBetaTestersQuery{})
 	})
 }
 
 func TestGetBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTesterResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBetaTester(ctx, "10", &GetBetaTesterQuery{})
 	})
 }
 
 func TestGetBetaTesterIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"apps"},{"type":"betaGroups"},{"type":"builds"}]}`, func(ctx context.Context, client *Client) {
 		tester, _, err := client.TestFlight.GetBetaTester(ctx, "10", &GetBetaTesterQuery{})
 		assert.NoError(t, err)
@@ -75,72 +85,96 @@ func TestGetBetaTesterIncludeds(t *testing.T) {
 }
 
 func TestAddBetaTesterToBetaGroups(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.AddBetaTesterToBetaGroups(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveBetaTesterFromBetaGroups(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.RemoveBetaTesterFromBetaGroups(ctx, "10", []string{"10"})
 	})
 }
 
 func TestAssignSingleBetaTesterToBuilds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.AssignSingleBetaTesterToBuilds(ctx, "10", []string{"10"})
 	})
 }
 
 func TestUnassignSingleBetaTesterFromBuilds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.UnassignSingleBetaTesterFromBuilds(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveSingleBetaTesterAccessApps(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.TestFlight.RemoveSingleBetaTesterAccessApps(ctx, "10", []string{"10"})
 	})
 }
 
 func TestListAppsForBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListAppsForBetaTester(ctx, "10", &ListAppsForBetaTesterQuery{})
 	})
 }
 
 func TestListAppIDsForBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTesterAppsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListAppIDsForBetaTester(ctx, "10", &ListAppIDsForBetaTesterQuery{})
 	})
 }
 
 func TestListBuildsIndividuallyAssignedToBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBuildsIndividuallyAssignedToBetaTester(ctx, "10", &ListBuildsIndividuallyAssignedToBetaTesterQuery{})
 	})
 }
 
 func TestListBuildIDsIndividuallyAssignedToBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTesterBuildsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBuildIDsIndividuallyAssignedToBetaTester(ctx, "10", &ListBuildIDsIndividuallyAssignedToBetaTesterQuery{})
 	})
 }
 
 func TestListIndividualTestersForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTestersResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListIndividualTestersForBuild(ctx, "10", &ListIndividualTestersForBuildQuery{})
 	})
 }
 
 func TestListBetaGroupsForBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaGroupsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaGroupsForBetaTester(ctx, "10", &ListBetaGroupsForBetaTesterQuery{})
 	})
 }
 
 func TestListBetaGroupIDsForBetaTester(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BetaTesterBetaGroupsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBetaGroupIDsForBetaTester(ctx, "10", &ListBetaGroupIDsForBetaTesterQuery{})
 	})

--- a/asc/testflight_build_beta_details_test.go
+++ b/asc/testflight_build_beta_details_test.go
@@ -26,30 +26,40 @@ import (
 )
 
 func TestListBuildBetaDetails(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildBetaDetailsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBuildBetaDetails(ctx, &ListBuildBetaDetailsQuery{})
 	})
 }
 
 func TestGetBuildBetaDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildBetaDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBuildBetaDetail(ctx, "10", &GetBuildBetaDetailsQuery{})
 	})
 }
 
 func TestGetBuildForBuildBetaDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBuildForBuildBetaDetail(ctx, "10", &GetBuildForBuildBetaDetailQuery{})
 	})
 }
 
 func TestGetBuildBetaDetailForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildBetaDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetBuildBetaDetailForBuild(ctx, "10", &GetBuildBetaDetailForBuildQuery{})
 	})
 }
 
 func TestUpdateBuildBetaDetail(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildBetaDetailResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.UpdateBuildBetaDetail(ctx, "10", Bool(false))
 	})

--- a/asc/testflight_build_beta_notifications_test.go
+++ b/asc/testflight_build_beta_notifications_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestCreateAvailableBuildNotification(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildBetaNotificationResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.CreateAvailableBuildNotification(ctx, "")
 	})

--- a/asc/testflight_prerelease_versions_test.go
+++ b/asc/testflight_prerelease_versions_test.go
@@ -28,18 +28,24 @@ import (
 )
 
 func TestListPrereleaseVersions(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &PrereleaseVersionsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListPrereleaseVersions(ctx, &ListPrereleaseVersionsQuery{})
 	})
 }
 
 func TestGetPrereleaseVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &PrereleaseVersionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetPrereleaseVersion(ctx, "10", &GetPrereleaseVersionQuery{})
 	})
 }
 
 func TestGetPrereleaseVersionIncludeds(t *testing.T) {
+	t.Parallel()
+
 	testEndpointCustomBehavior(`{"included":[{"type":"apps"},{"type":"builds"}]}`, func(ctx context.Context, client *Client) {
 		version, _, err := client.TestFlight.GetPrereleaseVersion(ctx, "10", &GetPrereleaseVersionQuery{})
 		assert.NoError(t, err)
@@ -53,24 +59,32 @@ func TestGetPrereleaseVersionIncludeds(t *testing.T) {
 }
 
 func TestGetAppForPrereleaseVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetAppForPrereleaseVersion(ctx, "10", &GetAppForPrereleaseVersionQuery{})
 	})
 }
 
 func TestListPrereleaseVersionsForApp(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &PrereleaseVersionsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListPrereleaseVersionsForApp(ctx, "10", &ListPrereleaseVersionsForAppQuery{})
 	})
 }
 
 func TestListBuildsForPrereleaseVersion(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &BuildsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.ListBuildsForPrereleaseVersion(ctx, "10", &ListBuildsForPrereleaseVersionQuery{})
 	})
 }
 
 func TestGetPrereleaseVersionForBuild(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &PrereleaseVersionResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.TestFlight.GetPrereleaseVersionForBuild(ctx, "10", &GetPrereleaseVersionForBuildQuery{})
 	})

--- a/asc/upload_operation_test.go
+++ b/asc/upload_operation_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestMultipartUpload(t *testing.T) {
+	t.Parallel()
+
 	file, err := os.CreateTemp("", "big_file")
 	if err != nil {
 		assert.FailNow(t, "temp file creation produced an error", err)
@@ -111,6 +113,8 @@ func TestMultipartUpload(t *testing.T) {
 }
 
 func TestUploadOperationChunk(t *testing.T) {
+	t.Parallel()
+
 	file, err := os.CreateTemp("", "small_file")
 	if err != nil {
 		assert.FailNow(t, "temp file creation produced an error", err)
@@ -152,6 +156,8 @@ func TestUploadOperationChunk(t *testing.T) {
 }
 
 func TestUploadOperationUploadError_InvalidOperation(t *testing.T) {
+	t.Parallel()
+
 	file, err := os.CreateTemp("", "big_file")
 	if err != nil {
 		assert.FailNow(t, "temp file creation produced an error", err)
@@ -190,6 +196,6 @@ func TestUploadOperationUploadError_InvalidOperation(t *testing.T) {
 // rmFile closes an open descriptor.
 func rmFile(f *os.File) {
 	if err := os.Remove(f.Name()); err != nil {
-		fmt.Println(err)
+		fmt.Println(err) // nolint: forbidigo
 	}
 }

--- a/asc/users.go
+++ b/asc/users.go
@@ -239,6 +239,7 @@ func (s *UsersService) UpdateUser(ctx context.Context, id string, attributes *Us
 // https://developer.apple.com/documentation/appstoreconnectapi/remove_a_user_account
 func (s *UsersService) RemoveUser(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("users/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 
@@ -269,6 +270,7 @@ func (s *UsersService) ListVisibleAppsByResourceIDForUser(ctx context.Context, i
 // https://developer.apple.com/documentation/appstoreconnectapi/add_visible_apps_to_a_user
 func (s *UsersService) AddVisibleAppsForUser(ctx context.Context, id string, appIDs []string) (*Response, error) {
 	linkages := newPagedRelationshipDeclaration(appIDs, "apps")
+
 	return s.client.post(ctx, "appStoreReviewDetails", newRequestBody(linkages.Data), nil)
 }
 

--- a/asc/users_invitations.go
+++ b/asc/users_invitations.go
@@ -177,6 +177,7 @@ func (s *UsersService) CreateInvitation(ctx context.Context, attributes UserInvi
 // https://developer.apple.com/documentation/appstoreconnectapi/cancel_a_user_invitation
 func (s *UsersService) CancelInvitation(ctx context.Context, id string) (*Response, error) {
 	url := fmt.Sprintf("userInvitations/%s", id)
+
 	return s.client.delete(ctx, url, nil)
 }
 

--- a/asc/users_invitations_test.go
+++ b/asc/users_invitations_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestListInvitations(t *testing.T) {
+	t.Parallel()
+
 	email := Email("me@email.com")
 	want := &UserInvitationsResponse{
 		Data: []UserInvitation{
@@ -42,6 +44,8 @@ func TestListInvitations(t *testing.T) {
 }
 
 func TestGetInvitation(t *testing.T) {
+	t.Parallel()
+
 	email := Email("me@email.com")
 	want := &UserInvitationResponse{
 		Data: UserInvitation{
@@ -56,6 +60,8 @@ func TestGetInvitation(t *testing.T) {
 }
 
 func TestCreateInvitation(t *testing.T) {
+	t.Parallel()
+
 	email := Email("me@email.com")
 	want := &UserInvitationResponse{
 		Data: UserInvitation{
@@ -70,12 +76,16 @@ func TestCreateInvitation(t *testing.T) {
 }
 
 func TestCancelInvitation(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Users.CancelInvitation(ctx, "10")
 	})
 }
 
 func TestListVisibleAppsForInvitation(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Users.ListVisibleAppsForInvitation(ctx, "10", &ListVisibleAppsQuery{})
 	})

--- a/asc/users_test.go
+++ b/asc/users_test.go
@@ -26,54 +26,72 @@ import (
 )
 
 func TestListUsers(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &UsersResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Users.ListUsers(ctx, &ListUsersQuery{})
 	})
 }
 
 func TestGetUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &UserResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Users.GetUser(ctx, "10", &GetUserQuery{})
 	})
 }
 
 func TestUpdateUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &UserResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Users.UpdateUser(ctx, "10", &UserUpdateRequestAttributes{}, []string{"10"})
 	})
 }
 
 func TestRemoveUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Users.RemoveUser(ctx, "10")
 	})
 }
 
 func TestListVisibleAppsForUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &AppsResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Users.ListVisibleAppsForUser(ctx, "10", &ListVisibleAppsQuery{})
 	})
 }
 
 func TestListVisibleAppsByResourceIDForUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithResponse(t, "{}", &UserVisibleAppsLinkagesResponse{}, func(ctx context.Context, client *Client) (interface{}, *Response, error) {
 		return client.Users.ListVisibleAppsByResourceIDForUser(ctx, "10", &ListVisibleAppsByResourceIDQuery{})
 	})
 }
 
 func TestAddVisibleAppsForUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Users.AddVisibleAppsForUser(ctx, "10", []string{"10"})
 	})
 }
 
 func TestUpdateVisibleAppsForUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Users.UpdateVisibleAppsForUser(ctx, "10", []string{"10"})
 	})
 }
 
 func TestRemoveVisibleAppsFromUser(t *testing.T) {
+	t.Parallel()
+
 	testEndpointWithNoContent(t, func(ctx context.Context, client *Client) (*Response, error) {
 		return client.Users.RemoveVisibleAppsFromUser(ctx, "10", []string{"10"})
 	})


### PR DESCRIPTION
Change adds `t.Parallel()` to all tests, `t.Helper()` to some helper functions, and adds newlines ahead of returns in nearly all functions. 